### PR TITLE
Bugfix: When creating a batch job with frame encoding + video, video …

### DIFF
--- a/AfterScan.py
+++ b/AfterScan.py
@@ -2518,6 +2518,7 @@ def video_generation_loop():
                 "\'Skip Frame regeneration\' is not selected, and try again.")
             generation_exit()  # Restore all settings to normal
         else:
+            get_target_dir_file_list()  # Refresh target dir file list here as well for batch mode encoding
             logging.debug(
                 "First filename in list: %s, extracted number: %s",
                 os.path.basename(SourceDirFileList[0]), first_absolute_frame)


### PR DESCRIPTION
…encoding was failing when calling mpeg, as it was delivered wid an image size of 0x0. To prevent this, the target directory is reloaded before each video is to be generated.