### PR TITLE
Reinstate custom template button

### DIFF
--- a/AfterScan.py
+++ b/AfterScan.py
@@ -19,7 +19,7 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.9.19"
+__version__ = "1.9.20"
 __date__ = "2024-01-23"
 __version_highlight__ = "Bring back custom templates"
 __maintainer__ = "Juan Remirez de Esparza"
@@ -60,7 +60,7 @@ import random
 import threading
 import queue
 from matplotlib import font_manager
-from tooltip import disable_tooltips, setup_tooltip, show_tooltip, init_tooltips
+from tooltip import disable_tooltips, setup_tooltip, init_tooltips
 
 # Frame vars
 first_absolute_frame = 0
@@ -1596,7 +1596,6 @@ def debug_template_popup():
     #label = Label(left_frame, text="Current template:")
     #label.pack(pady=5, padx=10, anchor=W)
 
-    height = film_hole_template.shape[0]
     file = SourceDirFileList[CurrentFrame]
     img = cv2.imread(file, cv2.IMREAD_UNCHANGED)
     image_height = img.shape[0]

--- a/AfterScan.py
+++ b/AfterScan.py
@@ -19,7 +19,7 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.9.18"
+__version__ = "1.9.19"
 __date__ = "2024-01-23"
 __version_highlight__ = "Bring back custom templates"
 __maintainer__ = "Juan Remirez de Esparza"
@@ -2025,6 +2025,10 @@ def select_rectangle_area(is_cropping=False):
         rectangle_refresh = True
 
     file = SourceDirFileList[CurrentFrame]
+    # If HDR mode, pick the ligthest frame to select rectangle
+    file3 = os.path.join(SourceDir, FrameHdrInputFilenamePattern % (CurrentFrame + 1, 2))
+    if os.path.isfile(file3):  # If hdr frames exist, add them
+        file = file3
 
     # load the image, clone it, and setup the mouse callback function
     original_image = cv2.imread(file, cv2.IMREAD_UNCHANGED)

--- a/AfterScan.py
+++ b/AfterScan.py
@@ -19,7 +19,7 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.9.16"
+__version__ = "1.9.17"
 __date__ = "2024-01-23"
 __version_highlight__ = "Bring back custom templates"
 __maintainer__ = "Juan Remirez de Esparza"
@@ -2175,8 +2175,8 @@ def select_cropping_area():
             win.update()  # Force an update to apply the cursor change
             set_best_template(int(frame_from_str.get()), int(frame_to_str.get()))
             win.config(cursor="")
-        select_scale_frame(ReferenceFrame)
-        frame_slider.set(ReferenceFrame)
+            select_scale_frame(ReferenceFrame)
+            frame_slider.set(ReferenceFrame)
         project_config["HolePos"] = expected_hole_template_pos
         project_config["HoleScale"] = film_hole_template_scale
         win.update()  # Force an update to apply the cursor change
@@ -2913,7 +2913,7 @@ def set_hole_search_area(img):
     # Adjust left stripe width (search area)
     img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     img_bw = cv2.threshold(img_gray, 240, 255, cv2.THRESH_BINARY)[1]
-    img_target = img_bw
+    img_target = img_bw[:, :int(img_bw.shape[1]/3)]  # Search only in the third left of the image
     # Detect corner in image, to adjust search area width
     result = cv2.matchTemplate(img_target, film_corner_template, cv2.TM_CCOEFF_NORMED)
     (minVal, maxVal, minLoc, maxLoc) = cv2.minMaxLoc(result)
@@ -3244,6 +3244,7 @@ def frame_encoding_thread(queue, event, id):
                         frame_update_ui(message[1], merged)
             elif message[0] == END_TOKEN:
                 logging.debug(f"Thread {id}: Received terminate token, exiting")
+                break
         logging.debug(f"Exiting frame_encoding_thread n.{id}")
         queue_item = tuple(("exit_thread", id))
         subprocess_event_queue.put(queue_item)
@@ -4386,7 +4387,7 @@ def build_ui():
         extra_row += 1
 
         # Check box to display postprod info, only if developer enabled
-        if developer_debug:
+        if True or developer_debug:
             display_template = tk.BooleanVar(value=False)
             display_template_checkbox = tk.Checkbutton(extra_frame,
                                                      text='Display template troubleshooting info',

--- a/AfterScan.py
+++ b/AfterScan.py
@@ -19,7 +19,7 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.9.15"
+__version__ = "1.9.16"
 __date__ = "2024-01-23"
 __version_highlight__ = "Bring back custom templates"
 __maintainer__ = "Juan Remirez de Esparza"
@@ -4069,7 +4069,7 @@ def build_ui():
     setup_tooltip(perform_stabilization_checkbox, "Check to stabilize frames. Sprocket hole is used as common reference, it needs to be clearly visible.")
     # Label to display the match level of current frame to template
     stabilization_threshold_match_label = Label(postprocessing_frame, width=4, borderwidth=1, relief='sunken', font=("Arial", FontSize))
-    stabilization_threshold_match_label.grid(row=postprocessing_row, column=0, sticky=E)
+    stabilization_threshold_match_label.grid(row=postprocessing_row, column=1, sticky=W)
     setup_tooltip(stabilization_threshold_match_label, "This value shows the dynamic quality of sprocket hole template matching. Green is good, orange acceptable, red is bad.")
 
     # Extended search checkbox (replace radio buttons for fast/precise stabilization)
@@ -4078,8 +4078,21 @@ def build_ui():
         postprocessing_frame, text='Extended search',
         variable=extended_stabilization, onvalue=True, offvalue=False, width=20,
         command=extended_stabilization_selection, font=("Arial", FontSize))
-    extended_stabilization_checkbox.grid(row=postprocessing_row, column=1, columnspan=2)
+    #extended_stabilization_checkbox.grid(row=postprocessing_row, column=1, columnspan=2)
+    extended_stabilization_checkbox.forget()
     setup_tooltip(extended_stabilization_checkbox, "Check to xtend the area where AfterScan looks for sprocket holes. In some rare cases this might help.")
+
+    # Custom film perforation template
+    custom_stabilization_btn = Button(postprocessing_frame,
+                                      text='Custom hole template',
+                                      width=16, height=1,
+                                      command=select_custom_template,
+                                      activebackground='green',
+                                      activeforeground='white', font=("Arial", FontSize))
+    custom_stabilization_btn.config(relief=SUNKEN if CustomTemplateDefined else RAISED)
+    custom_stabilization_btn.grid(row=postprocessing_row, column=1, columnspan=2, padx=5, pady=5, sticky=E)
+    setup_tooltip(custom_stabilization_btn,
+                  "If you prefer to use a customized template for your project, instead of the automatic one selected by AfterScan, lick on this button to define it.")
 
     postprocessing_row += 1
 
@@ -4352,23 +4365,12 @@ def build_ui():
         extra_frame.pack(side=TOP, padx=5, pady=5, ipadx=5, ipady=5)
         extra_row = 0
 
-        # Custom film perforation template
-        custom_stabilization_btn = Button(extra_frame,
-                                          text='Custom hole template',
-                                          width=16, height=1,
-                                          command=select_custom_template,
-                                          activebackground='green',
-                                          activeforeground='white', font=("Arial", FontSize))
-        custom_stabilization_btn.config(relief=SUNKEN if CustomTemplateDefined else RAISED)
-        custom_stabilization_btn.grid(row=extra_row, column=0, columnspan=1, padx=5, pady=5, sticky=W)
-        setup_tooltip(custom_stabilization_btn, "If you prefer to use a customized template for your project, instead of the automatic one selected by AfterScan, lick on this button to define it.")
-
-        # Spinbox to select stabilization threshold
+        # Spinbox to select stabilization threshold - Ignored, to be removed in the future
         stabilization_threshold_label = tk.Label(extra_frame,
                                                  text='Threshold:',
                                                  width=11, font=("Arial", FontSize))
-        stabilization_threshold_label.grid(row=extra_row, column=1,
-                                           columnspan=1, sticky=E)
+        #stabilization_threshold_label.grid(row=extra_row, column=1, columnspan=1, sticky=E)
+        stabilization_threshold_label.forget()
         stabilization_threshold_str = tk.StringVar(value=str(StabilizationThreshold))
         stabilization_threshold_selection_aux = extra_frame.register(
             stabilization_threshold_selection)
@@ -4376,7 +4378,8 @@ def build_ui():
             extra_frame,
             command=(stabilization_threshold_selection_aux, '%d'), width=6,
             textvariable=stabilization_threshold_str, from_=0, to=255, font=("Arial", FontSize))
-        stabilization_threshold_spinbox.grid(row=extra_row, column=2, sticky=W)
+        #stabilization_threshold_spinbox.grid(row=extra_row, column=2, sticky=W)
+        stabilization_threshold_spinbox.forget()
         stabilization_threshold_spinbox.bind("<FocusOut>", stabilization_threshold_spinbox_focus_out)
         setup_tooltip(stabilization_threshold_spinbox, "Threshold value to isolate the sprocket hole from the rest of the image while definint the custom template.")
 


### PR DESCRIPTION
AfterScan 1.9.20
- Bring back 'Custom template button'. Automatic templates stay as default option, but since they were not working fine in all cases custom template button is reinstated as a regular option. 
- Fix random error happening when stopping threads
- Various fixes and enhancements related to this change
- New option available in 'Extra options' (-x in command line): 'Display template troubleshooting info'. Useful to determine the quality of a custom template. Displays the template itself as well and the match in the target image, together with some technical info used during the development. Can be used with and without stabilization enabled, which can be used to have some visual feedback about how good (or bad) a custom template is 