### PR TITLE
AfterScan 1.11.12

### DIFF
--- a/AfterScan.py
+++ b/AfterScan.py
@@ -19,10 +19,10 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2024, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.11.11"
+__version__ = "1.11.12"
 __data_version__ = "1.0"
-__date__ = "2025-02-02"
-__version_highlight__ = "Fix bug: Window size in Mac OS too small"
+__date__ = "2025-02-04"
+__version_highlight__ = "Fix custom template handling, standardize filenames"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -822,7 +822,7 @@ def decode_project_config():
     if 'ExtendedStabilization' in project_config:
         extended_stabilization.set(project_config["ExtendedStabilization"])
 
-    if 'CustomTemplateDefined' in project_config and project_config["CustomTemplateDefined"] and 'CustomTemplateFilename' in project_config:
+    if 'CustomTemplateDefined' in project_config and project_config["CustomTemplateDefined"]:
         if 'CustomTemplateName' in project_config:  # Load name if it exists, otherwise assign default
             template_name = project_config["CustomTemplateName"]
         else:
@@ -834,10 +834,12 @@ def decode_project_config():
             expected_hole_template_pos_custom = project_config["CustomTemplateExpectedPos"]
         else:
             expected_hole_template_pos_custom = (0, 0)
-        template_filename = f"Pattern.custom.{template_name}.jpg"
-        full_path_template_filename = os.path.join(temp_dir, template_filename)
-        project_custom_template_filename = project_config["CustomTemplateFilename"]
-        if project_custom_template_filename != full_path_template_filename:
+        if 'CustomTemplateFilename' in project_config:
+            full_path_template_filename = project_config["CustomTemplateFilename"]
+        else:
+            template_filename = f"Pattern.custom.{template_name}.jpg"
+            full_path_template_filename = os.path.join(temp_dir, template_filename)
+        if not os.path.exists(full_path_template_filename):
             tk.messagebox.showwarning(
                 "Template in project invalid",
                 f"The custom template saved for project {template_name} is invalid."
@@ -1585,7 +1587,8 @@ def widget_status_update(widget_state=0, button_action=0):
 def update_frame_from(event):
     global frame_from_str, frame_slider
     global CurrentFrame
-    if len(frame_from_str.get()) == 0:
+    
+    if len(frame_from_str.get()) == 0 or event.num == 2:
         frame_from_str.set(CurrentFrame)
     else:
         select_scale_frame(frame_from_str.get())
@@ -1595,7 +1598,7 @@ def update_frame_from(event):
 def update_frame_to(event):
     global frame_to_str, frame_slider
     global CurrentFrame
-    if len(frame_to_str.get()) == 0:
+    if len(frame_to_str.get()) == 0 or event.num == 2:
         frame_to_str.set(CurrentFrame)
     else:
         select_scale_frame(frame_to_str.get())
@@ -4318,6 +4321,7 @@ def build_ui():
     frame_from_entry.grid(row=postprocessing_row, column=1, sticky=W)
     frame_from_entry.config(state=NORMAL)
     frame_from_entry.bind("<Double - Button - 1>", update_frame_from)
+    frame_from_entry.bind("<Button - 2>", update_frame_from)
     frame_from_entry.bind('<<Paste>>', lambda event, entry=frame_from_entry: on_paste_all_entries(event, entry))
     as_tooltips.add(frame_from_entry, "First frame to be processed, if not encoding the entire set")
     frame_to_str = tk.StringVar(value=str(from_frame))
@@ -4327,6 +4331,7 @@ def build_ui():
     frame_to_entry.grid(row=postprocessing_row, column=1, sticky=E)
     frame_to_entry.config(state=NORMAL)
     frame_to_entry.bind("<Double - Button - 1>", update_frame_to)
+    frame_to_entry.bind("<Button - 2>", update_frame_to)
     frame_to_entry.bind('<<Paste>>', lambda event, entry=frame_to_entry: on_paste_all_entries(event, entry))
     as_tooltips.add(frame_to_entry, "Last frame to be processed, if not encoding the entire set")
 

--- a/AfterScan.py
+++ b/AfterScan.py
@@ -19,10 +19,10 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2024, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.11.10"
+__version__ = "1.11.11"
 __data_version__ = "1.0"
-__date__ = "2024-11-26"
-__version_highlight__ = "Fix bug: When in error, match template returned 3 parameters instead of 4"
+__date__ = "2025-02-02"
+__version_highlight__ = "Fix bug: Window size in Mac OS too small"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -4083,20 +4083,14 @@ def afterscan_init():
         app_height = PreviewHeight + 330
 
     win.title('AfterScan ' + __version__)  # setting title of the window
-    win.geometry('1080x700')  # setting the size of the window
-    win.geometry('+50+50')  # setting the position of the window
     if 'WindowPos' in general_config:
          win.geometry(f"+{general_config['WindowPos'].split('+', 1)[1]}")
-    # Prevent window resize
-    win.minsize(app_width, app_height)
-    win.maxsize(app_width, app_height)
 
     win.update_idletasks()
 
     # Set default font size
     # Change the default Font that will affect in all the widgets
     win.option_add("*font", "TkDefaultFont 10")
-    win.resizable(False, False)
 
     # Init ToolTips
     as_tooltips = Tooltips(FontSize)
@@ -5012,6 +5006,8 @@ def main(argv):
         frame_slider.set(CurrentFrame)
 
     init_display()
+
+    win.resizable(False, False) # Lock window size once all widgets have been added (make sure all fits)
 
     # If BatchAutostart, enable suspend on completion and start batch
     if BatchAutostart:


### PR DESCRIPTION
- Fix issue with custom template filenames: Default filename and specific filename (based on video filename) where mixed up at project load time, which was a problem specially when processing job lists.
-  Allow pasting current frame in from/to edit boxes by clicking the mouse middle button, even if the edit box is not empty (but content must not be selected, otherwise it will be added on top)